### PR TITLE
feat: add magicgraph, regression tests, and bug fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,10 @@ jobs:
         run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y dpkg-dev dos2unix rlpr lpr pdftk qrencode imagemagick perl
+        run: sudo apt-get update && sudo apt-get install -y dpkg-dev dos2unix rlpr lpr pdftk qrencode imagemagick gnuplot perl
+
+      - name: Run test suite
+        run: bash tests/run_tests.sh
 
       - name: Build .deb
         run: fakeroot make

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y qrencode imagemagick gnuplot dos2unix
+
+      - name: Run test suite
+        run: bash tests/run_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DEBIAN_DIR=$(BUILD_DIR)/DEBIAN
 DEB_FILE=$(PACKAGE_NAME)_$(VERSION)_$(ARCH).deb
 
 FONTS=fonts/*.ttf
-SCRIPTS=magicpcl magicqr magicspool
+SCRIPTS=magicpcl magicqr magicspool magicgraph
 BINARIES=pcl6
 
 all: clean build
@@ -34,10 +34,11 @@ control:
 	@printf "Priority: optional\n" >> $(DEBIAN_DIR)/control
 	@printf "Architecture: %s\n" "$(ARCH)" >> $(DEBIAN_DIR)/control
 	@printf "Maintainer: Diego J. Coppari <diego2k[_at_]gmail.com>\n" >> $(DEBIAN_DIR)/control
-	@printf "Depends: bash, perl, dos2unix, rlpr, lpr, pdftk, qrencode, imagemagick\n" >> $(DEBIAN_DIR)/control
-	@printf "Description: MagicSpool Utilities (magicpcl, magicqr, magicspool)\n" >> $(DEBIAN_DIR)/control
+	@printf "Depends: bash, perl, dos2unix, rlpr, lpr, pdftk, qrencode, imagemagick, gnuplot\n" >> $(DEBIAN_DIR)/control
+	@printf "Description: MagicSpool Utilities (magicpcl, magicqr, magicspool, magicgraph)\n" >> $(DEBIAN_DIR)/control
 	@printf " Suite of tools to process PCL input streams, generate QR codes as PCL,\n" >> $(DEBIAN_DIR)/control
-	@printf " apply background to PDFs and handle remote spool via magicspooler.\n" >> $(DEBIAN_DIR)/control
+	@printf " generate monochrome charts (pie/bar/line) as PCL, apply background to PDFs,\n" >> $(DEBIAN_DIR)/control
+	@printf " and handle remote spool via magicspooler.\n" >> $(DEBIAN_DIR)/control
 	@printf " Includes bundled pcl6 binary and required TTF fonts in /windows/fonts.\n" >> $(DEBIAN_DIR)/control
 
 copy-scripts:

--- a/OPENEDGE.md
+++ b/OPENEDGE.md
@@ -327,3 +327,143 @@ RUN magicspool.p (
 - **`SESSION_ID` vacío**: si la variable de entorno no está seteada, el servidor rechaza el mensaje con `ERROR: Missing required attribute`.
 
 - **Debug**: cada llamada sobreescribe `/tmp/[SESSION_ID]_last_message.xml` con el XML enviado — útil para diagnosticar sin necesidad de sniffear el socket.
+
+---
+
+## Impresión directa de PCL desde OpenEdge
+
+Los scripts `magicqr` y `magicgraph` generan archivos `.pcl` listos para enviar a impresora. El
+siguiente procedimiento genérico los invoca, lee el binario resultante en memoria y lo envía al
+contexto de impresión activo (`OUTPUT TO PRINTER`).
+
+### Procedimiento auxiliar `magic-utils`
+
+```openedge
+PROCEDURE magic-utils:
+    DEF INPUT PARAMETER wutil AS CHAR NO-UNDO.  /* nombre del script: magicqr | magicgraph */
+    DEF INPUT PARAMETER warg  AS CHAR NO-UNDO.  /* argumentos del script                  */
+    DEF INPUT PARAMETER wx    AS INT  NO-UNDO.  /* posición X en puntos PCL (1/720 pulg.)  */
+    DEF INPUT PARAMETER wy    AS INT  NO-UNDO.  /* posición Y en puntos PCL (1/720 pulg.)  */
+
+    DEF VAR mMyMemPtr AS MEMPTR NO-UNDO.
+    DEF VAR wfilename AS CHAR   NO-UNDO.
+    DEF VAR wCmd      AS CHAR   NO-UNDO.
+
+    wfilename = '/tmp/' + USERID("USERINFO") + '/output.pcl'.
+    wCmd = SUBSTITUTE('&1 &2 "&3"', wutil, warg, wfilename).
+
+    UNIX SILENT VALUE(wCmd).
+
+    IF SEARCH(wfilename) = ? THEN RETURN.
+
+    FILE-INFO:FILE-NAME = wfilename.
+    SET-SIZE(mMyMemPtr) = FILE-INFO:FILE-SIZE.
+
+    INPUT FROM VALUE(FILE-INFO:FILE-NAME) BINARY NO-MAP NO-CONVERT.
+    IMPORT mMyMemPtr.
+    INPUT CLOSE.
+
+    /* Posicionar cursor antes de volcar el PCL */
+    PUT CONTROL CHR(27) + '*r0F'.
+    PUT CONTROL CHR(27) + '*p' + STRING(wx) + 'x' + STRING(wy) + 'Y'.
+
+    EXPORT mMyMemPtr.
+
+    SET-SIZE(mMyMemPtr) = 0.
+    UNIX SILENT VALUE('rm -f ' + wfilename).
+END PROCEDURE.
+```
+
+### Coordenadas PCL
+
+| Secuencia                          | Significado                                              |
+|------------------------------------|----------------------------------------------------------|
+| `ESC *r0F`                         | Finaliza cualquier bloque de gráficos raster abierto     |
+| `ESC *p<x>x<y>Y`                   | Mueve el cursor a la posición absoluta (X, Y)            |
+| 1 punto PCL = 1/720 de pulgada     | A 300 dpi: 1 punto PCL ≈ 2,4 px                         |
+
+Conversión rápida: `puntos_pcl = pulgadas × 720 = mm × 720 / 25.4`
+
+---
+
+### Ejemplo: imprimir un código QR
+
+```openedge
+OUTPUT TO PRINTER.
+
+RUN magic-utils(
+    'magicqr',
+    '"https://ejemplo.com/factura/1234"',
+    100,   /* X: ~3,5 mm desde el margen izquierdo */
+    200    /* Y: ~7 mm desde la parte superior      */
+).
+
+OUTPUT CLOSE.
+```
+
+---
+
+### Ejemplo: imprimir un gráfico de torta
+
+```openedge
+OUTPUT TO PRINTER.
+
+RUN magic-utils(
+    'magicgraph',
+    'pie "Ventas:40,Costos:30,Otros:30" 600 600',
+    500,
+    1000
+).
+
+OUTPUT CLOSE.
+```
+
+---
+
+### Ejemplo: imprimir un gráfico de barras desde CSV
+
+```openedge
+DEF VAR wArgs AS CHAR NO-UNDO.
+wArgs = 'bar /tmp/ventas.csv 1000 600'.
+
+OUTPUT TO PRINTER.
+RUN magic-utils('magicgraph', wArgs, 500, 2000).
+OUTPUT CLOSE.
+```
+
+---
+
+### Ejemplo: QR y gráfico en la misma página
+
+```openedge
+OUTPUT TO PRINTER.
+
+/* QR en esquina superior derecha */
+RUN magic-utils(
+    'magicqr',
+    '"https://ejemplo.com/doc/9999"',
+    4500, 200
+).
+
+/* Gráfico de barras debajo */
+RUN magic-utils(
+    'magicgraph',
+    'bar "Ene:120,Feb:95,Mar:140" 2000 1200',
+    500, 1500
+).
+
+OUTPUT CLOSE.
+```
+
+---
+
+### Consideraciones
+
+- El directorio `/tmp/<usuario>/` debe existir antes de llamar al procedimiento. Se puede crear con
+  `UNIX SILENT VALUE('mkdir -p /tmp/' + USERID("USERINFO"))`.
+- `warg` se pasa como un único string; los valores con espacios deben ir entre comillas dobles
+  dentro del string (ver ejemplos de `magicgraph`).
+- Si el script no está en el `PATH` del proceso OpenEdge, usar la ruta absoluta:
+  `/usr/local/bin/magicqr` en lugar de `magicqr`.
+- El procedimiento hace `RETURN` silenciosamente si el archivo PCL no se generó (error en el
+  script externo). Verificar con `UNIX VALUE(wCmd)` sin `SILENT` para capturar el código de salida.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 [![Build and Release .deb](https://github.com/dcoppari/magic-utils/actions/workflows/build.yml/badge.svg)](https://github.com/dcoppari/magic-utils/actions/workflows/build.yml)
 
-**Magic Utils** is a lightweight set of tools for converting PCL to PDF, generating printable QR codes, and remotely spooling documents. It's built for legacy environments, and automated printing workflows.
+**Magic Utils** is a lightweight set of tools for converting PCL to PDF, generating printable QR codes, generating charts, and remotely spooling documents. It's built for legacy environments and automated printing workflows.
 
 Included tools:
 
 - `magicpcl`: converts PCL to PDF, applies background overlays, sends to printer or spools.
 - `magicqr`: generates a QR code and outputs a PCL-ready file.
+- `magicgraph`: generates a pie, bar, or line chart and outputs a PCL-ready file.
 - `magicspool`: sends a Base64-encoded PDF over TCP to a remote spool server.
 - `pcl6`: bundled binary to convert PCL to PDF.
 - `fonts` font files for standalone usage (required by pcl6).
@@ -28,8 +29,9 @@ The following files will be installed:
 ```
 /usr/local/bin/magicpcl
 /usr/local/bin/magicqr
+/usr/local/bin/magicgraph
 /usr/local/bin/magicspool
-/usr/local/bin/pcl6-magic
+/usr/local/bin/pcl6
 /windows/fonts/*.ttf
 ```
 
@@ -42,11 +44,12 @@ The package includes the `pcl6` binary, but requires the following system tools 
 - `bash`, `perl`
 - `dos2unix`, `rlpr`, `lpr`
 - `pdftk`, `qrencode`, `imagemagick`
+- `gnuplot` (required by `magicgraph`)
 
 If installing on Ubuntu or Debian, they will be installed automatically if declared in a `.deb` or can be installed manually:
 
 ```bash
-sudo apt install dos2unix rlpr lpr pdftk qrencode imagemagick
+sudo apt install dos2unix rlpr lpr pdftk qrencode imagemagick gnuplot
 ```
 
 ---
@@ -71,6 +74,19 @@ cat file.pcl | magicpcl -D output.pdf NoBackground PrinterName
 magicqr "https://example.com/invoice/1234" qr-code.pcl
 ```
 
+### Generate a chart and convert to PCL
+
+```bash
+# Inline data
+magicgraph pie "Ventas:40,Costos:30,Otros:30" torta.pcl 800 800
+
+# From a CSV file
+magicgraph bar ventas.csv barras.pcl 1000 600
+
+# Line chart with default size (600x600)
+magicgraph line consumo.csv linea.pcl
+```
+
 ### Send a file to a remote spooler
 
 ```bash
@@ -92,6 +108,12 @@ This will produce:
 ```
 magic-utils_1.0.0_amd64.deb
 ```
+
+## 📖 OpenEdge / Progress ABL
+
+See [OPENEDGE.md](OPENEDGE.md) for:
+- Using `magicspool.p` to send files, URLs, and notifications to a browser frontend.
+- Printing QR codes and charts directly from ABL using `magicqr` and `magicgraph`.
 
 ---
 

--- a/magicgraph
+++ b/magicgraph
@@ -1,0 +1,257 @@
+#!/bin/bash
+#
+# MagicGraph generates a chart (pie/bar/line) and outputs a PCL-ready file
+# (c) 2008-2026 Diego Javier Coppari – LGPL License
+#
+
+set -euo pipefail
+
+# Help message
+show_help() {
+  cat <<EOF
+Usage: $(basename "$0") <type> <data> <output_file> [width] [height]
+
+Generates a chart and converts it into a PCL file ready for printing.
+Output is monochrome (distinct fills/hatching) so it stays legible on
+black-and-white printers.
+
+Arguments:
+  type          Chart type: pie | bar | line
+  data          Either inline "label:value" pairs separated by commas
+                (e.g. "Ventas:40,Costos:30,Otros:30"), or a path to a
+                two-column CSV "label,value" (header auto-detected).
+  output_file   The resulting .pcl file ready for use.
+  width         Final PNG width in pixels  (optional, default 600).
+  height        Final PNG height in pixels (optional, default 600).
+
+Examples:
+  $(basename "$0") pie  "Ventas:40,Costos:30,Otros:30" torta.pcl 800 800
+  $(basename "$0") bar  ventas.csv                      barras.pcl 1000 600
+  $(basename "$0") line consumo.csv                     linea.pcl
+
+This script is part of the MagicSpool solution by Diego J. Coppari.
+Licensed under the terms of the LGPL.
+(c) 2008-2026 Diego Javier Coppari
+
+Contact:
+   https://github.com/dcoppari
+
+EOF
+}
+
+# Validate required commands
+require_commands() {
+  for cmd in "$@"; do
+    command -v "$cmd" >/dev/null 2>&1 || {
+      echo "Error: Required command '$cmd' not found in PATH." >&2
+      exit 1
+    }
+  done
+}
+
+# Check exit status of critical steps
+# Must be called immediately after the command to check.
+assert_success() {
+  local exit_code=$?
+  local message="$1"
+  if [ "$exit_code" -ne 0 ]; then
+    echo "Error: $message" >&2
+    exit 1
+  fi
+}
+
+# Detect ImageMagick convert command (v6: 'convert', v7: 'magick')
+detect_convert() {
+  if command -v magick >/dev/null 2>&1; then
+    echo "magick"
+  elif command -v convert >/dev/null 2>&1; then
+    echo "convert"
+  else
+    echo "Error: Required command 'magick' or 'convert' not found in PATH." >&2
+    exit 1
+  fi
+}
+
+# Validate arguments
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  show_help; exit 0
+fi
+if [ "$#" -lt 3 ] || [ "$#" -gt 5 ]; then
+  show_help; exit 1
+fi
+
+# Inputs
+CHART_TYPE="$1"
+CHART_DATA="$2"
+OUTPUT_FILE="$3"
+WIDTH="${4:-600}"
+HEIGHT="${5:-600}"
+
+# Validate chart type
+case "$CHART_TYPE" in
+  pie|bar|line) ;;
+  *) echo "Error: unsupported type '$CHART_TYPE' (expected: pie|bar|line)." >&2; exit 1 ;;
+esac
+
+# Validate that width/height are positive integers
+if ! [[ "$WIDTH" =~ ^[0-9]+$ && "$HEIGHT" =~ ^[0-9]+$ && "$WIDTH" -gt 0 && "$HEIGHT" -gt 0 ]]; then
+  echo "Error: width and height must be positive integers." >&2
+  exit 1
+fi
+
+require_commands gnuplot dd truncate mktemp awk
+CONVERT_CMD="$(detect_convert)"
+
+# Initialize temp file vars before trap so cleanup is safe under set -u
+TMP_PREFIX="" CHART_IMAGE="" RAW_PCL="" GNUPLOT_SCRIPT="" DATA_FILE=""
+
+# Ensure cleanup on exit
+cleanup() {
+  rm -f "${TMP_PREFIX:-}" "${CHART_IMAGE:-}" "${RAW_PCL:-}" "${GNUPLOT_SCRIPT:-}" "${DATA_FILE:-}"
+}
+trap cleanup EXIT
+
+# Temporary files
+TMP_PREFIX="$(mktemp)"
+CHART_IMAGE="${TMP_PREFIX}.png"
+RAW_PCL="${TMP_PREFIX}.pcl"
+GNUPLOT_SCRIPT="${TMP_PREFIX}.gp"
+DATA_FILE="${TMP_PREFIX}.dat"
+
+# Step 1: Normalize input into a TAB-separated "label<TAB>value" data file.
+# Accepts a CSV path or an inline "label:value,..." string.
+if [ -f "$CHART_DATA" ]; then
+  awk -F',' '
+    function trim(s){ gsub(/^[ \t\r]+|[ \t\r]+$/,"",s); return s }
+    {
+      l = trim($1); v = trim($2)
+      # Skip a header row when the value column is not numeric
+      if (NR == 1 && v !~ /^-?[0-9]+(\.[0-9]+)?$/) next
+      if (l == "") next
+      printf "%s\t%s\n", l, v
+    }
+  ' "$CHART_DATA" > "$DATA_FILE"
+else
+  awk -v data="$CHART_DATA" '
+    function trim(s){ gsub(/^[ \t]+|[ \t]+$/,"",s); return s }
+    BEGIN {
+      n = split(data, pairs, ",")
+      for (i = 1; i <= n; i++) {
+        split(pairs[i], kv, ":")
+        if (trim(kv[1]) == "") continue
+        printf "%s\t%s\n", trim(kv[1]), trim(kv[2])
+      }
+    }
+  ' > "$DATA_FILE"
+fi
+assert_success "Failed to parse input data."
+
+[ -s "$DATA_FILE" ] || {
+  echo "Error: no valid data parsed from input." >&2
+  exit 1
+}
+
+# Step 2: Build the gnuplot script for the requested chart type
+{
+  echo "set terminal pngcairo size ${WIDTH},${HEIGHT} background rgb 'white'"
+  echo "set output '${CHART_IMAGE}'"
+  echo "set datafile separator \"\t\""
+
+  case "$CHART_TYPE" in
+    pie)
+      echo "set size square"
+      echo "unset border; unset tics; unset key"
+      echo "set xrange [-1.5:1.5]; set yrange [-1.5:1.5]"
+      LC_NUMERIC=C awk -F'\t' '
+        BEGIN {
+          style[0]="fc rgb \"black\"  fs solid 1.0"
+          style[1]="fc rgb \"white\"  fs solid 1.0"
+          style[2]="fc rgb \"black\"  fs pattern 4"
+          style[3]="fc rgb \"black\"  fs pattern 5"
+          style[4]="fc rgb \"gray50\" fs solid 1.0"
+          style[5]="fc rgb \"black\"  fs pattern 1"
+          nstyles = 6
+          pi = 3.14159265358979
+        }
+        {
+          v = $2 + 0
+          if (v < 0) {
+            print "Warning: skipping negative value for label \"" $1 "\"" > "/dev/stderr"
+            next
+          }
+          label[NR]=$1; value[NR]=v; total+=v
+        }
+        END {
+          if (total <= 0) { print "set label \"no data\" at 0,0 center"; exit }
+          acc = 0
+          for (i = 1; i <= NR; i++) {
+            if (!(i in value)) continue
+            frac = value[i] / total * 360.0
+            a = 90 - acc - frac
+            b = 90 - acc
+            st = style[(i - 1) % nstyles]
+            printf "set object %d circle at 0,0 size 1 arc [%.4f:%.4f] %s border lc rgb \"black\"\n", i, a, b, st
+            mid = (a + b) / 2.0 * pi / 180.0
+            lx = 1.18 * cos(mid); ly = 1.18 * sin(mid)
+            pct = value[i] / total * 100.0
+            printf "set label %d \"%s %.1f%%\" at %.4f,%.4f center font \",10\"\n", i, label[i], pct, lx, ly
+            acc += frac
+          }
+        }
+      ' "$DATA_FILE"
+      echo "plot -10 notitle"
+      ;;
+
+    bar)
+      echo "set style data histograms"
+      echo "set style fill solid 1.0 border -1"
+      echo "set boxwidth 0.8 relative"
+      echo "set yrange [0:*]"
+      echo "set grid ytics lc rgb 'gray70'"
+      echo "set xtics rotate by -40 right"
+      echo "unset key"
+      echo "set lmargin 8; set bmargin 5"
+      echo "plot '${DATA_FILE}' using 2:xtic(1) lc rgb 'black' notitle"
+      ;;
+
+    line)
+      echo "set grid lc rgb 'gray70'"
+      echo "set xtics rotate by -40 right"
+      echo "unset key"
+      echo "set lmargin 8; set bmargin 5"
+      echo "set offsets graph 0.02, 0.02, 0.05, 0.05"
+      echo "plot '${DATA_FILE}' using 2:xtic(1) with linespoints lc rgb 'black' lw 2 pt 7 ps 1.2 notitle"
+      ;;
+  esac
+} > "$GNUPLOT_SCRIPT"
+assert_success "Failed to build gnuplot script."
+
+# Step 3: Render the chart as PNG
+gnuplot "$GNUPLOT_SCRIPT"
+assert_success "Failed to generate chart image."
+
+[ -s "$CHART_IMAGE" ] || {
+  echo "Error: Generated chart image is empty or missing." >&2
+  exit 1
+}
+
+# Step 4: Convert PNG to PCL (monochrome)
+"$CONVERT_CMD" -monochrome "$CHART_IMAGE" "$RAW_PCL"
+assert_success "Failed to convert image to PCL."
+
+[ -s "$RAW_PCL" ] || {
+  echo "Error: Generated PCL file is empty or missing." >&2
+  exit 1
+}
+
+# Step 5: Adjust PCL file - remove first 7 bytes, then last byte
+dd if="$RAW_PCL" of="$OUTPUT_FILE" bs=1 skip=7 status=none
+assert_success "Failed to trim first 7 bytes from PCL file."
+
+truncate -s -1 "$OUTPUT_FILE"
+assert_success "Failed to remove last byte from PCL file."
+
+[ -s "$OUTPUT_FILE" ] || {
+  echo "Error: Final PCL file is empty or invalid." >&2
+  exit 1
+}

--- a/magicpcl
+++ b/magicpcl
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # MagicPCL converts PCL to PDF, applies background overlays, sends to printer or spools.
-# (c) 2008 Diego Javier Coppari – LGLP License
+# (c) 2008-2026 Diego Javier Coppari – LGPL License
 #
 
 show_help() {

--- a/magicqr
+++ b/magicqr
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # MagicQR generates a QR code and outputs a PCL-ready file
-# (c) 2008 Diego Javier Coppari – LGLP License
+# (c) 2008-2026 Diego Javier Coppari – LGPL License
 #
 
 set -euo pipefail
@@ -41,27 +41,47 @@ require_commands() {
 }
 
 # Check exit status of critical steps
+# Must be called immediately after the command to check.
 assert_success() {
+  local exit_code=$?
   local message="$1"
-  if [ $? -ne 0 ]; then
+  if [ "$exit_code" -ne 0 ]; then
     echo "Error: $message" >&2
     exit 1
   fi
 }
 
+# Detect ImageMagick convert command (v6: 'convert', v7: 'magick')
+detect_convert() {
+  if command -v magick >/dev/null 2>&1; then
+    echo "magick"
+  elif command -v convert >/dev/null 2>&1; then
+    echo "convert"
+  else
+    echo "Error: Required command 'magick' or 'convert' not found in PATH." >&2
+    exit 1
+  fi
+}
+
 # Validate arguments
-if [ "$#" -ne 2 ] || [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  show_help
-  [ "$#" -ne 2 ] && exit 1 || exit 0
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  show_help; exit 0
 fi
+if [ "$#" -ne 2 ]; then
+  show_help; exit 1
+fi
+
+# Initialize temp file vars before trap so cleanup is safe under set -u
+TMP_PREFIX="" QR_IMAGE="" RAW_PCL=""
 
 # Ensure cleanup on exit
 cleanup() {
-  rm -f "$TMP_PREFIX" "$QR_IMAGE" "$RAW_PCL"
+  rm -f "${TMP_PREFIX:-}" "${QR_IMAGE:-}" "${RAW_PCL:-}"
 }
 trap cleanup EXIT
 
-require_commands qrencode convert dd truncate mktemp
+require_commands qrencode dd truncate mktemp
+CONVERT_CMD="$(detect_convert)"
 
 # Inputs
 QR_TEXT="$1"
@@ -77,7 +97,7 @@ qrencode -m0 -s2 -lL -o "$QR_IMAGE" "$QR_TEXT"
 assert_success "Failed to generate QR code image."
 
 # Step 2: Convert PNG to PCL (monochrome)
-convert -monochrome "$QR_IMAGE" "$RAW_PCL"
+"$CONVERT_CMD" -monochrome "$QR_IMAGE" "$RAW_PCL"
 assert_success "Failed to convert image to PCL."
 
 [ -s "$RAW_PCL" ] || {

--- a/tests/fixtures/sample.csv
+++ b/tests/fixtures/sample.csv
@@ -1,0 +1,5 @@
+label,value
+Enero,120
+Febrero,95
+Marzo,140
+Abril,110

--- a/tests/fixtures/sample_noheader.csv
+++ b/tests/fixtures/sample_noheader.csv
@@ -1,0 +1,5 @@
+Lunes,10
+Martes,15
+Miercoles,8
+Jueves,20
+Viernes,18

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# Regression test suite for magic-utils scripts.
+# Run from the project root: bash tests/run_tests.sh
+#
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURES="$SCRIPT_DIR/fixtures"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+magicqr="$ROOT_DIR/magicqr"
+magicgraph="$ROOT_DIR/magicgraph"
+magicpcl="$ROOT_DIR/magicpcl"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+pass() { echo "  PASS  $1"; ((PASS++)); }
+fail() { echo "  FAIL  $1"; ((FAIL++)); FAILURES+=("$1"); }
+
+# assert_exit <desc> <expected_exit> <cmd...>
+assert_exit() {
+  local desc="$1" expected="$2"; shift 2
+  local actual=0
+  "$@" >/dev/null 2>&1 || actual=$?
+  if [ "$actual" -eq "$expected" ]; then pass "$desc"; else fail "$desc (expected $expected, got $actual)"; fi
+}
+
+# assert_nonempty <desc> <file>
+assert_nonempty() {
+  local desc="$1" file="$2"
+  if [ -s "$file" ]; then pass "$desc"; else fail "$desc (empty or missing: $file)"; fi
+}
+
+# assert_stderr <desc> <pattern> <cmd...>
+assert_stderr() {
+  local desc="$1" pattern="$2"; shift 2
+  local stderr
+  stderr="$("$@" 2>&1 >/dev/null)" || true
+  if echo "$stderr" | grep -q "$pattern"; then pass "$desc"; else fail "$desc (pattern '$pattern' not found in stderr)"; fi
+}
+
+# ── magicqr ──────────────────────────────────────────────────────────────────
+
+echo "magicqr"
+
+assert_exit  "help flag exits 0"              0  "$magicqr" --help
+assert_exit  "no args exits 1"                1  "$magicqr"
+assert_exit  "one arg exits 1"                1  "$magicqr" "text-only"
+
+OUT="$TMP_DIR/qr.pcl"
+assert_exit  "inline URL exits 0"             0  "$magicqr" "https://github.com/dcoppari" "$OUT"
+assert_nonempty "inline URL produces PCL"        "$OUT"
+
+OUT="$TMP_DIR/qr_text.pcl"
+assert_exit  "plain text exits 0"             0  "$magicqr" "Hello World 123" "$OUT"
+assert_nonempty "plain text produces PCL"        "$OUT"
+
+# ── magicgraph ───────────────────────────────────────────────────────────────
+
+echo "magicgraph"
+
+assert_exit  "help flag exits 0"              0  "$magicgraph" --help
+assert_exit  "no args exits 1"                1  "$magicgraph"
+assert_exit  "bad type exits 1"               1  "$magicgraph" scatter "a:1" "$TMP_DIR/out.pcl"
+assert_exit  "bad width exits 1"              1  "$magicgraph" bar "a:1" "$TMP_DIR/out.pcl" abc 600
+assert_exit  "zero width exits 1"             1  "$magicgraph" bar "a:1" "$TMP_DIR/out.pcl" 0 600
+assert_exit  "zero height exits 1"            1  "$magicgraph" bar "a:1" "$TMP_DIR/out.pcl" 600 0
+assert_exit  "too many args exits 1"          1  "$magicgraph" bar "a:1" "$TMP_DIR/out.pcl" 600 600 extra
+
+OUT="$TMP_DIR/pie.pcl"
+assert_exit  "pie inline exits 0"             0  "$magicgraph" pie "Ventas:40,Costos:30,Otros:30" "$OUT" 800 800
+assert_nonempty "pie inline produces PCL"        "$OUT"
+
+OUT="$TMP_DIR/bar.pcl"
+assert_exit  "bar inline exits 0"             0  "$magicgraph" bar "Ene:120,Feb:95,Mar:140" "$OUT" 1000 600
+assert_nonempty "bar inline produces PCL"        "$OUT"
+
+OUT="$TMP_DIR/line.pcl"
+assert_exit  "line inline exits 0"            0  "$magicgraph" line "Lun:10,Mar:15,Mie:8" "$OUT"
+assert_nonempty "line inline produces PCL"       "$OUT"
+
+OUT="$TMP_DIR/bar_csv.pcl"
+assert_exit  "bar CSV with header exits 0"    0  "$magicgraph" bar "$FIXTURES/sample.csv" "$OUT" 1000 600
+assert_nonempty "bar CSV with header produces PCL" "$OUT"
+
+OUT="$TMP_DIR/line_csv.pcl"
+assert_exit  "line CSV no header exits 0"     0  "$magicgraph" line "$FIXTURES/sample_noheader.csv" "$OUT"
+assert_nonempty "line CSV no header produces PCL" "$OUT"
+
+OUT="$TMP_DIR/pie_neg.pcl"
+assert_exit  "pie with negative value exits 0" 0 "$magicgraph" pie "Ventas:40,Costos:-5,Otros:30" "$OUT" 600 600
+assert_stderr "pie negative value warns"     "Warning" \
+              "$magicgraph" pie "Ventas:40,Costos:-5,Otros:30" "$OUT" 600 600
+assert_nonempty "pie with negative value produces PCL" "$OUT"
+
+# ── magicpcl ─────────────────────────────────────────────────────────────────
+
+echo "magicpcl"
+
+assert_exit  "help flag exits 0"              0  "$magicpcl" --help
+assert_exit  "no args exits 0 (shows help)"   0  "$magicpcl"
+assert_exit  "bad option exits 1"             1  "$magicpcl" -Z /tmp/out.pdf
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "${#FAILURES[@]}" -gt 0 ]; then
+  echo ""
+  echo "Failed tests:"
+  for f in "${FAILURES[@]}"; do echo "  - $f"; done
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **New tool `magicgraph`**: generates pie, bar, and line charts as PCL files using gnuplot and ImageMagick, with monochrome output (fills/hatching) for B&W printers. Accepts inline `label:value` data or two-column CSV files.
- **Regression test suite** (`tests/run_tests.sh`): 30 tests covering argument validation, functional output, and edge cases for `magicqr`, `magicgraph`, and `magicpcl`.
- **New CI workflow** (`test.yml`): runs on every push and PR to master; `build.yml` also runs tests before building the `.deb`.
- **Bug fixes** in `magicqr`, `magicgraph`, and `magicpcl` (see below).
- **OpenEdge ABL docs**: new section in `OPENEDGE.md` covering direct PCL printing from Progress with examples for `magicqr` and `magicgraph`.

## Bug fixes

| Script | Bug | Fix |
|---|---|---|
| `magicqr`, `magicgraph` | `assert_success` never detected errors — `local` reset `$?` before the check | Capture `exit_code=$?` as first line |
| `magicqr`, `magicgraph` | `--help` returned exit 1 — arg count check ran before help flag check | Separate help check (exit 0) from arg count check (exit 1) |
| `magicqr`, `magicgraph` | Uninitialized trap variables under `set -u` | Initialize vars to `""` before `trap` |
| `magicqr` | Hardcoded `convert`, breaks on ImageMagick v7 | `detect_convert()` tries `magick` then `convert` |
| `magicgraph` | Locale-dependent decimal separator in gnuplot script (`,` instead of `.`) | `LC_NUMERIC=C awk` on pie chart generation |
| `magicgraph` | Arg validation ran after `require_commands` | Reordered: validate args first, then check deps |
| `magicpcl`, `magicqr` | Typo `LGLP` in header | Fixed to `LGPL`, updated copyright year to 2026 |
| `README.md` | Installed binary listed as `pcl6-magic`, actual name is `pcl6` | Fixed |

## Test plan

- [ ] CI `test.yml` workflow passes on this branch
- [ ] `bash tests/run_tests.sh` passes locally (30/30)
- [ ] `magicgraph pie "Ventas:40,Costos:30,Otros:30" torta.pcl 800 800` produces a valid PCL file
- [ ] `magicgraph bar ventas.csv barras.pcl` works with a CSV file
- [ ] `magicqr "https://example.com" qr.pcl` still works
- [ ] `magicqr --help` and `magicgraph --help` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)